### PR TITLE
Don't set @site.config["time"] on feed generation

### DIFF
--- a/lib/jekyll/jekyll-feed.rb
+++ b/lib/jekyll/jekyll-feed.rb
@@ -8,7 +8,6 @@ module Jekyll
     # Main plugin action, called by Jekyll-core
     def generate(site)
       @site = site
-      @site.config["time"] = Time.new
       unless file_exists?(feed_path)
         @site.pages << content_for_file(feed_path, feed_source_path)
       end


### PR DESCRIPTION
Setting @site.config["time"] causes problems when Jekyll is operating in `--draft` mode. See: https://github.com/jekyll/jekyll-feed/issues/135
